### PR TITLE
improve: cross-platform support for admin privilege check

### DIFF
--- a/slimta/app/helpers.py
+++ b/slimta/app/helpers.py
@@ -20,6 +20,7 @@
 #
 
 import math
+import os
 import socket
 from functools import wraps
 
@@ -263,6 +264,24 @@ def build_backoff_function(retry):
 
 def get_relay_credentials(creds):
     return (creds.username, creds.password)
+
+
+def is_running_as_admin():
+    """Check if the current process is running with administrative privileges.
+    
+    Returns True if running as root on Unix-like systems or as Administrator on Windows.
+    Returns False otherwise.
+    """
+    try:
+        # Unix-like systems (Linux, macOS, etc.)
+        if hasattr(os, 'getuid'):
+            return os.getuid() == 0
+        # Windows
+        else:
+            import ctypes
+            return ctypes.windll.shell32.IsUserAnAdmin() != 0
+    except Exception:
+        return False
 
 
 # vim:et:fdm=marker:sts=4:sw=4:ts=4

--- a/slimta/app/helpers.py
+++ b/slimta/app/helpers.py
@@ -268,9 +268,9 @@ def get_relay_credentials(creds):
 
 def is_running_as_admin():
     """Check if the current process is running with administrative privileges.
-    
-    Returns True if running as root on Unix-like systems or as Administrator on Windows.
-    Returns False otherwise.
+
+    Returns True if running as root on Unix-like systems or as Administrator on
+    Windows. Returns False otherwise.
     """
     try:
         # Unix-like systems (Linux, macOS, etc.)

--- a/slimta/app/setup.py
+++ b/slimta/app/setup.py
@@ -27,6 +27,7 @@ from string import Template
 from argparse import ArgumentParser
 
 from . import __version__
+from .helpers import is_running_as_admin
 
 
 def _confirm_overwrite(path, force=False):
@@ -56,7 +57,7 @@ def _try_config_copy(etc_dir, conf_file, force):
 def _setup_configs(parser, args):
     etc_dir = args.etc_dir
     default_etc_dir = '/etc/slimta'
-    if os.getuid() != 0:
+    if not is_running_as_admin():
         default_etc_dir = '~/.slimta/'
     if etc_dir is None:
         etc_dir = input(

--- a/slimta/app/state.py
+++ b/slimta/app/state.py
@@ -38,6 +38,7 @@ from .config import try_configs
 from .importutil import custom_factory
 from .listeners import Listeners
 from .logging import setup_logging
+from .helpers import is_running_as_admin
 
 try:
     from slimta.util import build_ipv4_socket_creator
@@ -121,7 +122,7 @@ class SlimtaState(object):
         user = process_options.user
         group = process_options.group
         if user or group:
-            if os.getuid() == 0:
+            if is_running_as_admin():
                 system.drop_privileges(user, group)
             else:
                 warnings.warn('Only superuser can drop privileges.')


### PR DESCRIPTION
This PR fixes compatibility issues on Windows related to checking administrative privileges.

Previously, the code used `os.getuid()`, which does not exist on Windows, causing runtime errors.
To fix this, I added a new helper `function is_running_as_admin()` that works across platforms. using os.getuid() on Unix-like systems and `ctypes.windll.shell32.IsUserAnAdmin()` on Windows.

This PR resolves the first issue described in Issue #16.

Happy to contribute!